### PR TITLE
remove repetitious DialSSH in the session layer

### DIFF
--- a/drivers/ssh/lowlevel/ssh.go
+++ b/drivers/ssh/lowlevel/ssh.go
@@ -116,7 +116,12 @@ func NewSSHSession(conn net.Conn, config *ssh.ClientConfig) (*session.Session, e
 		return nil, err
 	}
 
-	return session.NewSession(t), nil
+	s, err := session.NewSession(t)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // Dial creates a new NETCONF session using a SSH Transport.
@@ -127,7 +132,13 @@ func Dial(target string, config *ssh.ClientConfig, port int) (*session.Session, 
 	if err != nil {
 		return nil, err
 	}
-	return session.NewSession(&t), nil
+
+	s, err := session.NewSession(&t)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // DialSSHTimeout creates a new NETCONF session using a SSH Transport with timeout.
@@ -156,7 +167,12 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 		}
 	}()
 
-	return session.NewSession(t), nil
+	s, err := session.NewSession(t)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // SSHConfigPassword is a convenience function that takes a username and password

--- a/drivers/ssh/ssh.go
+++ b/drivers/ssh/ssh.go
@@ -51,7 +51,7 @@ func (d *DriverSSH) Dial() error {
 		return err
 	}
 
-	d.Session, err = lowlevel.Dial(d.Host, d.SSHConfig, d.Port)
+	d.Session = session.NewSession(d.Transport)
 
 	if err != nil {
 		return err

--- a/drivers/ssh/ssh.go
+++ b/drivers/ssh/ssh.go
@@ -51,12 +51,7 @@ func (d *DriverSSH) Dial() error {
 		return err
 	}
 
-	d.Session = session.NewSession(d.Transport)
-
-	if err != nil {
-		return err
-	}
-
+	d.Session, err = session.NewSession(d.Transport)
 	if err != nil {
 		return err
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -61,17 +61,20 @@ func (s *Session) Exec(methods ...rpc.RPCMethod) (*rpc.RPCReply, error) {
 }
 
 // NewSession creates a new NETCONF session using the provided transport layer.
-func NewSession(t transport.Transport) *Session {
+func NewSession(t transport.Transport) (*Session, error) {
 	s := new(Session)
 	s.Transport = t
 
 	// Receive Servers Hello message
-	serverHello, _ := t.ReceiveHello()
+	serverHello, err := t.ReceiveHello()
+	if err != nil {
+		return nil, err
+	}
 	s.SessionID = serverHello.SessionID
 	s.ServerCapabilities = serverHello.Capabilities
 
 	// Send our hello using default capabilities.
 	t.SendHello(&transport.HelloMessage{Capabilities: transport.DefaultCapabilities})
 
-	return s
+	return s, nil
 }


### PR DESCRIPTION
## 1
It seems to me that the original way of [initialising a session](https://github.com/arsonistgopher/go-netconf/blob/master/drivers/ssh/ssh.go#L54) uses a duplicated code that is called via 
```
	d.Session, err = lowlevel.Dial(d.Host, d.SSHConfig, d.Port)
``` 

The [lowlevel.Dial](https://github.com/arsonistgopher/go-netconf/blob/master/drivers/ssh/lowlevel/ssh.go#L124) function calls the same [Transport.DialSSH](https://github.com/arsonistgopher/go-netconf/blob/master/drivers/ssh/lowlevel/ssh.go#L126) function that is used to initialise the Transport struct.

The proposed change eliminates the second call to Transport.DialSSH and instantiates a Session struct using the Transport struct already created before in the `DialSSH` method of the TransportSSH struct

## 2

The second enhancement is with the NewSession func in the ssssion.go. I added an error propagation in this func, so we can track if any error happened during the NETCONF session establishment.
This change required to change some return statements where the NewSession func was used as a return value 